### PR TITLE
When using database backend: mention pg_trgm extension to address pg_trgm error 

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -292,7 +292,7 @@ Once you have the postgres server running on your machine and access to the psql
 ```bash
 psql postgres://username:password@localhost:5432/ -c "CREATE DATABASE assetdb"
 psql postgres://username:password@localhost:5432/ -c "ALTER DATABASE assetdb SET TIMEZONE to 'UTC'"
-psql postgres://username:password@localhost:5432/assetdb -c "CREATE EXTENSION pg_trgm;"
+psql postgres://username:password@localhost:5432/assetdb -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
 ```
 
 Now you can add the following setting into your Amass `config.yaml` file for storing and analyzing attack surface discoveries using PostgreSQL:

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -292,6 +292,7 @@ Once you have the postgres server running on your machine and access to the psql
 ```bash
 psql postgres://username:password@localhost:5432/ -c "CREATE DATABASE assetdb"
 psql postgres://username:password@localhost:5432/ -c "ALTER DATABASE assetdb SET TIMEZONE to 'UTC'"
+psql postgres://username:password@localhost:5432/assetdb -c "CREATE EXTENSION pg_trgm;"
 ```
 
 Now you can add the following setting into your Amass `config.yaml` file for storing and analyzing attack surface discoveries using PostgreSQL:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -25,7 +25,7 @@ options:
   wordlist: # global wordlist(s) to uses 
     - "./wordlists/deepmagic.com_top50kprefixes.txt"
     - "./wordlists/deepmagic.com_top500prefixes.txt"
-  database: "postgres://username:password@localhost:5432/database?testing=works" # databases URI to be used when adding entries
+  database: "postgres://username:password@localhost:5432/assetdb?testing=works" # databases URI to be used when adding entries
   bruteforce: # specific option to use when brute forcing is needed
     enabled: true
     wordlists: # wordlist(s) to use that are specific to brute forcing


### PR DESCRIPTION
Address sql extension error
When I configured the postgresql database backend,  I got the following error: 

```
./amass enum -rf resolvers.txt -d owasp.org -config ~/.config/amass/config.yaml
panic: ERROR: operator class "gin_trgm_ops" does not exist for access method "gin" (SQLSTATE 42704) handling 005_assets_indexes.sql
```

The `pg_trgm` postgresql extension was not enabled. on the database I was using. 
I encountered this on Ubuntu 22.04.3 LTS but I am sure others will enounter this as well. 