### PR TITLE
fix typo in JSON unmarshal error message

### DIFF
--- a/internal/afmt/slog.go
+++ b/internal/afmt/slog.go
@@ -17,7 +17,7 @@ func JSONLogToRecord(logstr string) (slog.Record, error) {
 	j := make(map[string]any)
 	// unmarshal the log message sent from the engine session
 	if err := json.Unmarshal([]byte(logstr), &j); err != nil {
-		return slog.Record{}, errors.New("failed to unmarchal the JSON")
+		return slog.Record{}, errors.New("failed to unmarshal the JSON")
 	}
 
 	ltime := time.Now()


### PR DESCRIPTION
## Summary

Fixes a typo in a user-facing error message in internal/afmt/slog.go: "failed to unmarchal the JSON" → "failed to unmarshal the JSON".

## Details

The JSONLogToRecord function returns this error when it fails to unmarshal a log message sent from the engine session.
The misspelled word "unmarchal" would surface to users in logs/error output. Notably, the same function already uses the correct spelling 20 lines below ("failed to unmarshal the level text"), confirming this was an oversight.

## Changes

  • internal/afmt/slog.go: 1 line changed (error string only, no behavior change)

## Verification

  • go build ./internal/afmt/ and go vet ./internal/afmt/ pass
  • Grep confirms no other occurrences of "unmarchal" remain in the codebase