### PR TITLE
fix(enum): don't abort enumeration on a missing/empty -nf file

### DIFF
--- a/internal/enum/files.go
+++ b/internal/enum/files.go
@@ -7,6 +7,7 @@ package enum
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/caffix/stringset"
 	"github.com/owasp-amass/amass/v5/config"
@@ -58,8 +59,19 @@ func processInputFiles(args *Args) error {
 	if err := getList([]string{args.Filepaths.Blacklist}, "blacklist", args.Blacklist); err != nil {
 		return err
 	}
-	if err := getList(args.Filepaths.Names, "subdomain names", args.Names); err != nil {
-		return err
+	// The subdomain names file (-nf) only supplies supplementary names discovered by other
+	// means; unlike the other input files it's optional, so a missing, empty, or otherwise
+	// unparseable file shouldn't abort the whole enumeration. Warn and continue instead.
+	for _, p := range args.Filepaths.Names {
+		if p == "" {
+			continue
+		}
+		list, err := config.GetListFromFile(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse the subdomain names file: %v\n", err)
+			continue
+		}
+		args.Names.InsertMany(list...)
 	}
 	if err := getList(args.Filepaths.Domains, "domain names", args.Domains); err != nil {
 		return err


### PR DESCRIPTION
## Summary

`processInputFiles()` in `internal/enum/files.go` treats a failure to read *any* input file as fatal (`os.Exit(1)`) — including the `-nf` subdomain-names file. Unlike `-df` (root domains) or the resolvers/blacklist files, `-nf` only supplies supplementary names discovered by other means and is explicitly optional (per its own `-h` description: "Path to a file providing already known subdomain names (from other tools/sources)"), so there's no reason a missing or empty `-nf` file should prevent the whole enumeration from running.

Fixes #996

## Changes

- `internal/enum/files.go`: the `-nf` file(s) are now read in their own loop instead of via the shared fatal `getList` helper. A missing/empty/unparseable file now prints a warning to stderr and enumeration continues, instead of aborting via `os.Exit(1)`. Behavior for the other input files (blacklist, `-df` domains, resolvers) is unchanged.

## Verification

No Go toolchain is available in the environment I used to write this fix, so I wasn't able to run `go build`/`go test`. I verified the change by careful reading:
- Traced `-nf` → `args.Filepaths.Names` → `processInputFiles` → the shared `getList` closure that returns a hard error → the caller in `argsAndConfig` (`internal/enum/cli.go`) that prints the error and calls `os.Exit(1)` on *any* `processInputFiles` error, confirming today's abort-on-missing-`-nf`-file behavior exactly as reported.
- The replacement loop reuses the exact same `config.GetListFromFile`/`stringset.InsertMany` calls already used by the existing `getList` closure for every other input file, just without propagating the error upward — same code shape used elsewhere in this file (e.g. the brute-force/alterations wordlist fallbacks a few lines above already tolerate a failed file read without aborting).
- `fmt.Fprintf(os.Stderr, ...)` without checking the return error matches an existing pattern already in this codebase (`cmd/ae_isready/main.go`), so it should be consistent with the project's lint config.

Happy to add a unit test/adjust the fix if a Go environment turns up a build issue I couldn't catch this way.