### PR TITLE
Carry the alteration technique flags across the enum to engine handoff (#1140)

### DIFF
--- a/config/active_test.go
+++ b/config/active_test.go
@@ -36,7 +36,7 @@ func TestActive(t *testing.T) {
 
 	// Test case 1: MarshalJSON returns the expected JSON bytes
 	t.Run("TestActive returns the expected JSON bytes", func(t *testing.T) {
-		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"active":true,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
+		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"flip_words":true,"flip_numbers":true,"add_words":true,"add_numbers":true,"min_for_word_flip":2,"edit_distance":1,"active":true,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
 `)
 		_ = c.loadActiveSettings(c)
 		got, err := c.JSON()
@@ -51,7 +51,7 @@ func TestActive(t *testing.T) {
 
 	t.Run("TestActive returns the expected JSON bytes when active isnt provided", func(t *testing.T) {
 		c := NewConfig()
-		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
+		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"flip_words":true,"flip_numbers":true,"add_words":true,"add_numbers":true,"min_for_word_flip":2,"edit_distance":1,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
 `)
 
 		got, err := c.JSON()
@@ -69,7 +69,7 @@ func TestActive(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
+		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"flip_words":true,"flip_numbers":true,"add_words":true,"add_numbers":true,"min_for_word_flip":2,"edit_distance":1,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
 `)
 
 		_ = c.loadActiveSettings(c)

--- a/config/alterations_test.go
+++ b/config/alterations_test.go
@@ -1,0 +1,77 @@
+// Copyright © by Jeff Foley 2017-2026. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The engine unmarshals into a fresh Config, so an untagged field arrives zeroed
+// and every generator gated on it goes quiet.
+func TestAlterationKnobsSurviveTheEngineHandoff(t *testing.T) {
+	cli := NewConfig()
+	cli.Alterations = true
+	cli.FlipWords = false
+	cli.FlipNumbers = false
+	cli.AddWords = true
+	cli.AddNumbers = true
+	cli.EditDistance = 0
+	cli.MinForWordFlip = 3
+	cli.AltWordlist = []string{"dev", "staging"}
+
+	raw, err := json.Marshal(cli)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var engine Config
+	if err := json.Unmarshal(raw, &engine); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if !engine.Alterations {
+		t.Error("Alterations did not survive the handoff")
+	}
+	if engine.FlipWords || engine.FlipNumbers {
+		t.Errorf("flip generators should be off: flipWords=%v flipNumbers=%v", engine.FlipWords, engine.FlipNumbers)
+	}
+	if !engine.AddWords || !engine.AddNumbers {
+		t.Errorf("add generators did not survive: addWords=%v addNumbers=%v", engine.AddWords, engine.AddNumbers)
+	}
+	if engine.EditDistance != 0 {
+		t.Errorf("EditDistance = %d, want 0", engine.EditDistance)
+	}
+	if engine.MinForWordFlip != 3 {
+		t.Errorf("MinForWordFlip = %d, want 3", engine.MinForWordFlip)
+	}
+	if len(engine.AltWordlist) != 2 {
+		t.Errorf("AltWordlist = %v, want 2 entries", engine.AltWordlist)
+	}
+}
+
+// The same handoff with the NewConfig defaults, which is the common case.
+func TestAlterationDefaultsSurviveTheEngineHandoff(t *testing.T) {
+	cli := NewConfig()
+	cli.Alterations = true
+
+	raw, err := json.Marshal(cli)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var engine Config
+	if err := json.Unmarshal(raw, &engine); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if !engine.FlipWords || !engine.FlipNumbers || !engine.AddWords || !engine.AddNumbers {
+		t.Errorf("generator defaults did not survive: flipWords=%v flipNumbers=%v addWords=%v addNumbers=%v",
+			engine.FlipWords, engine.FlipNumbers, engine.AddWords, engine.AddNumbers)
+	}
+	if engine.EditDistance != 1 {
+		t.Errorf("EditDistance = %d, want 1", engine.EditDistance)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -95,13 +95,15 @@ type Config struct {
 	MaxDepth int `yaml:"-" json:"-"`
 
 	// Will discovered subdomain name alterations be generated?
+	// The generator flags cross the wire to the engine, so they cannot be
+	// json:"-": alterations.go gates every generator on one of them.
 	Alterations    bool     `yaml:"-" json:"alterations,omitempty"`
-	FlipWords      bool     `yaml:"-" json:"-"`
-	FlipNumbers    bool     `yaml:"-" json:"-"`
-	AddWords       bool     `yaml:"-" json:"-"`
-	AddNumbers     bool     `yaml:"-" json:"-"`
-	MinForWordFlip int      `yaml:"-" json:"-"`
-	EditDistance   int      `yaml:"-" json:"-"`
+	FlipWords      bool     `yaml:"-" json:"flip_words"`
+	FlipNumbers    bool     `yaml:"-" json:"flip_numbers"`
+	AddWords       bool     `yaml:"-" json:"add_words"`
+	AddNumbers     bool     `yaml:"-" json:"add_numbers"`
+	MinForWordFlip int      `yaml:"-" json:"min_for_word_flip"`
+	EditDistance   int      `yaml:"-" json:"edit_distance"`
 	AltWordlist    []string `yaml:"-" json:"alt_worldlist,omitempty"`
 
 	// Only access the data sources for names and return results?

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,7 +168,7 @@ func TestMarshalJSON(t *testing.T) {
 
 	// Test case 1: MarshalJSON returns the expected JSON bytes
 	t.Run("MarshalJSON returns the expected JSON bytes", func(t *testing.T) {
-		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
+		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"flip_words":true,"flip_numbers":true,"add_words":true,"add_numbers":true,"min_for_word_flip":2,"edit_distance":1,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
 `)
 		got, err := c.JSON()
 		if err != nil {
@@ -187,7 +187,7 @@ func TestMarshalJSON(t *testing.T) {
 	}
 	// Test case 2: MarshalJSON unescapes HTML entities in the JSON bytes
 	t.Run("MarshalJSON unescapes HTML entities in the JSON bytes", func(t *testing.T) {
-		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"database":[{"system":"postgres","primary":true,"url":"postgres://postgres:testPasWORD123456!)*&*$@localhost:5432","username":"postgres","password":"testPasWORD123456!)*&*$","host":"localhost","port":"5432"}],"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
+		expected := []byte(`{"seed":{},"scope":{"ports":[80,443]},"database":[{"system":"postgres","primary":true,"url":"postgres://postgres:testPasWORD123456!)*&*$@localhost:5432","username":"postgres","password":"testPasWORD123456!)*&*$","host":"localhost","port":"5432"}],"flip_words":true,"flip_numbers":true,"add_words":true,"add_numbers":true,"min_for_word_flip":2,"edit_distance":1,"rigid_boundaries":false,"resolvers":null,"datasource_config":{},"transformations":{}}
 `)
 		expectedString := string(expected)
 		got, err := c.JSON()


### PR DESCRIPTION
Disclaimer up front: I'm **not** a Go developer and this PR was AI-assisted. I traced the code paths and added tests that fail without the change, but please treat it as a good-faith contribution. Careful inspection would be appreciated.

This is a fix for #1140, which someone else opened a couple of days ago. I had run into the same thing and had a patch sitting in a fork, so I am offering it rather than leaving the issue without one. @t0kubetsu, apologies if you were already partway through your own, happy to close this in favour of yours.

## Summary

`amass enum -brute -alts` generates no altered names. The run exits 0, with no output and no error.

## Root cause

The enum CLI marshals its `config.Config` to JSON and POSTs it to the engine, which unmarshals into a fresh zero value `config.Config`. Any field tagged `json:"-"` therefore arrives at its zero value on the engine side, and `NewConfig`'s defaults never apply there.

Six fields were tagged that way:

```go
FlipWords      bool `yaml:"-" json:"-"`
FlipNumbers    bool `yaml:"-" json:"-"`
AddWords       bool `yaml:"-" json:"-"`
AddNumbers     bool `yaml:"-" json:"-"`
MinForWordFlip int  `yaml:"-" json:"-"`
EditDistance   int  `yaml:"-" json:"-"`
```

Every generator in `engine/plugins/brute/alterations.go` is gated on one of them, so the engine sees all four bools false and both counts zero, and each generator returns without emitting anything. `Alterations` itself is tagged `json:"alterations,omitempty"`, so the plugin runs, it just has nothing enabled to run.

This is option A of the three you were offered in the issue.

## Changes

Give the six fields real JSON tags. The `yaml:"-"` tags are left alone, since this only concerns what crosses the wire.

Two round trip tests in `config/alterations_test.go` marshal a `Config` and unmarshal it the way the engine does, one with the defaults and one with a mixed set of values. Both fail on `develop` and pass with the change.

The three existing expected-JSON fixtures in `config_test.go` and `active_test.go` pick up the new keys.

## Notes

`MinForWordFlip` and `EditDistance` deliberately have no `omitempty`. Zero is meaningful for both, since it disables the generator it drives, so absence and zero need to stay distinguishable on the engine side. That does mean six extra keys appear in every marshalled config, which is why those three fixtures had to change.

Two things I noticed but left alone, since they are not this fix:

- `alterations.go` gates the whole plugin on `!cfg.BruteForcing || !cfg.Alterations`, so `-alts` on its own still does nothing even with this change. You need `-brute -alts`. That may well be intended, but it is surprising, and it is part of why the issue reads as "generates nothing".
- `MinForWordFlip` is defaulted in `NewConfig` but nothing under `engine/` reads it. I gave it a tag for consistency with the other five rather than leave one field behind, but it is currently inert.

I did not regenerate `docs/swagger.yaml` and `docs/docs.go`, which list config fields by JSON tag and will now be missing six. Running `swag init` here produced a few hundred lines of unrelated churn, so I assume my version does not match yours. Happy to regenerate if you tell me which one you use, or to leave it for whoever next runs it.
